### PR TITLE
Altered the empty message and added a unit test for event, also made …

### DIFF
--- a/app/src/Action/HomeAction.php
+++ b/app/src/Action/HomeAction.php
@@ -47,11 +47,12 @@ final class HomeAction
     public function dispatch($request, $response, $args)
     {
         $event = null;
-        $eventExists = true;
         $previousEvents = null;
         try  {
 
             $event = $this->eventService->getLatestEvent();
+
+            $eventExists = strlen($event->getDescription()) > 0 ?? false;
 
             $previousEvents = $this->eventService->getPastEvents();
 

--- a/app/src/Model/Event/Entity/Event.php
+++ b/app/src/Model/Event/Entity/Event.php
@@ -22,7 +22,7 @@ class Event
 
     private $meetupDate;
 
-    public function __construct($meetupID, $meetupVenueID, $joindinEventName, $joindinTalkID, $joindinURL, $speakerID, $supporterID, \DateTime $meetupDate)
+    public function __construct($meetupID, $meetupVenueID, $joindinEventName, $joindinTalkID, $joindinURL, $speakerID, $supporterID, ?\DateTime $meetupDate)
     {
         $this->meetupID         = $meetupID;
         $this->meetupVenueID    = $meetupVenueID;

--- a/app/templates/home.twig
+++ b/app/templates/home.twig
@@ -22,9 +22,11 @@
             </div>
             {% else %}
                 <div class="p-summary">
-                    <h3>
-                        There are no published events. Please check again soon.
-                    </h3>
+                    <p>
+                        There are no details for the next event at the moment. Please check again soon. Or drop along to meetup
+                        to find out future dates and or events.
+                    </p>
+                    <p class="right"><a class="button alert" href="{{ meetUpURL }}">Visit Meetup</a></p>
                 </div>
             {% endif %}
         </div>

--- a/app/templates/home.twig
+++ b/app/templates/home.twig
@@ -26,7 +26,7 @@
                         There are no details for the next event at the moment. Please check again soon. Or drop along to meetup
                         to find out future dates and or events.
                     </p>
-                    <p class="right"><a class="button alert" href="{{ meetUpURL }}">Visit Meetup</a></p>
+                    <p class="right"><a class="button alert" href="https://www.meetup.com/PHPMiNDS-in-Nottingham">Visit Meetup</a></p>
                 </div>
             {% endif %}
         </div>

--- a/tests/phpunit/Model/Event/Entity/EventTest.php
+++ b/tests/phpunit/Model/Event/Entity/EventTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace PHPMinds\Tests\Model\Event\Entity;
+
+use PHPMinds\Model\Event\Entity\Event;
+
+class EventTest extends \PHPUnit_Framework_TestCase
+{
+    protected $event;
+
+    /**
+     * TEST for events - please note not testing setters or getters cos no complexity
+     */
+    public function setUp()
+    {
+        $this->event = new Event(
+
+            1,
+            1,
+            'test',
+            1,
+            'http://TEST',
+            1,
+            1,
+            new \DateTime('now')
+
+        );
+
+    }
+
+    public function testCanConstructValidEvent()
+    {
+        $this->assertInstanceOf(Event::class, $this->event);
+    }
+
+    public function testCreate()
+    {
+        $actual = Event::create(
+            ['meetup_id' => 1,]
+        );
+        $this->assertInstanceOf(Event::class, $actual);
+
+       $properties = get_object_vars($actual);
+
+       self::assertNull($properties['id']);
+       self::assertEquals(1, $actual->getMeetupID());
+
+    }
+}


### PR DESCRIPTION
…datetime nullable to comply with the way static create works

This hopefully will address the empty screen when the event is not published from meetup