### PR TITLE
[travis] Fix: Use Composer's `phpunit`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: php
 php: '7.1'
 install: composer install
-script: phpunit --configuration tests/phpunit/phpunit.xml
+script: bin/phpunit --configuration tests/phpunit/phpunit.xml
 


### PR DESCRIPTION
It appears that up until now we've been pretty lucky in terms of `phpunit`
working, as it appears it's been using a globally installed version of
`phpunit`, not the one we've been pinning with Composer.

When Composer installs `phpunit`, it places its source files into
`vendor/` but the executable into `bin/` which means all we need to do
is update the path to explicitly use the `composer install`'d version of
`phpunit`.